### PR TITLE
Contactsync is broken again with XZ

### DIFF
--- a/scripts/inc.compatibility.sh
+++ b/scripts/inc.compatibility.sh
@@ -404,3 +404,11 @@ sdkversionhacks(){
     *) ;;
   esac
 }
+
+compressioncompathack(){
+  if [ "$API" -ge "23" ]; then
+    case "$1" in
+      googlecontactssync*) compression="none";; # Googlecontactssync extraction is broken on some devices with XZ on marshmallow, if we compress it in any way while the rest of the package is xz compressed
+    esac
+  fi
+}

--- a/scripts/inc.packagetarget.sh
+++ b/scripts/inc.packagetarget.sh
@@ -102,6 +102,7 @@ bundlelicense() {
 
 compressapp() {
   compression="$COMPRESSION"
+  compressioncompathack "$2"
   case "$compression" in
     xz) checktools xz
         csuf=".xz"


### PR DESCRIPTION
Fixes #.
## Changes:
## 
## 

@opengapps/developers

Revert "Remove compressioncompathack; googlecontactssync extraction works with updated APK"

This reverts commit 3d71dc3925bd4e16626a9201f55e9e90cb51c119.
